### PR TITLE
Remove fragment resolution classes which were removed upstream

### DIFF
--- a/lib/graphql/parallel/execution_strategy.rb
+++ b/lib/graphql/parallel/execution_strategy.rb
@@ -1,6 +1,6 @@
 module GraphQL
   module Parallel
-    class ExecutionStrategy < GraphQL::Query::BaseExecution
+    class ExecutionStrategy < GraphQL::Query::SerialExecution
       def initialize
         # Why isn't `require "celluloid/current"` enough here?
         Celluloid.boot unless Celluloid.running?
@@ -55,9 +55,6 @@ module GraphQL
         end
       end
 
-      class SelectionResolution < GraphQL::Query::SerialExecution::SelectionResolution
-      end
-
       class FieldResolution < GraphQL::Query::SerialExecution::FieldResolution
         def get_finished_value(raw_value)
           if raw_value.is_a?(Celluloid::Future)
@@ -66,12 +63,6 @@ module GraphQL
             super
           end
         end
-      end
-
-      class InlineFragmentResolution < GraphQL::Query::SerialExecution::InlineFragmentResolution
-      end
-
-      class FragmentSpreadResolution < GraphQL::Query::SerialExecution::FragmentSpreadResolution
       end
     end
   end


### PR DESCRIPTION
## Problem

Use graphql 0.9.3 and run the test suite, and you will get an `uninitialized constant GraphQL::Query::SerialExecution::InlineFragmentResolution (NameError)`

This was caused by https://github.com/rmosolgo/graphql-ruby/pull/34 removing the fragment resolution classes.
## Solution

I removed the empty fragment resolution classes, and changed the executor's base class to `GraphQL::Query::SerialExecution` so that it will continue working with earlier versions of the graphql gem and because it is already used as a base class for the resolution classes.
